### PR TITLE
Disable lint for iothub_client which is a C extension module

### DIFF
--- a/{{cookiecutter.module_name}}/main.py
+++ b/{{cookiecutter.module_name}}/main.py
@@ -6,6 +6,7 @@ import random
 import time
 import sys
 import iothub_client
+# pylint: disable=E0611
 from iothub_client import IoTHubModuleClient, IoTHubClientError, IoTHubTransportProvider
 from iothub_client import IoTHubMessage, IoTHubMessageDispositionResult, IoTHubError
 


### PR DESCRIPTION
Pylint has limit to support a C extension module, so disable lint for iothub_client as https://github.com/Azure-Samples/azure-iot-samples-python/blob/7a5a959fc62580152f4d9d10851e1d11a1860b94/iot-hub/Quickstarts/simulated-device/SimulatedDevice.py#L12