### PR TITLE
Use ENTRYPOINT instead of CMD

### DIFF
--- a/{{cookiecutter.module_name}}/Dockerfile.arm32v7
+++ b/{{cookiecutter.module_name}}/Dockerfile.arm32v7
@@ -14,4 +14,4 @@ COPY . .
 RUN useradd -ms /bin/bash moduleuser
 USER moduleuser
 
-CMD [ "python", "-u", "./main.py" ]
+ENTRYPOINT [ "python", "-u", "./main.py" ]


### PR DESCRIPTION
Otherwise, would meet with below errors:
```
Python 2.7.15 (default, Jun 22 2018, 18:43:23)
[GCC 4.9.2]

IoT Hub Client for Python
Starting the IoT Hub Python sample using protocol MQTT...
The sample is now waiting for messages and will indefinitely.  Press Ctrl-C to exit.
Error: Time:Mon Aug 13 05:47:45 2018 File:/usr/sdk/src/c/provisioning_client/adapters/hsm_client_http_edge.c Func:on_edge_hsm_http_recv Line:364 executing HTTP request fails, status=404, response_buffer={"message":"Module not found"}n, 13 )
Error: Time:Mon Aug 13 05:47:45 2018 File:/usr/sdk/src/c/provisioning_client/adapters/hsm_client_http_edge.c Func:on_edge_hsm_http_error Line:343 on_edge_hsm_http_error invoked.  reason=3
Error: Time:Mon Aug 13 05:47:45 2018 File:/usr/sdk/src/c/provisioning_client/adapters/hsm_client_http_edge.c Func:send_http_workload_request Line:483 send_request_to_edge_workload failed
Error: Time:Mon Aug 13 05:47:45 2018 File:/usr/sdk/src/c/provisioning_client/adapters/hsm_client_http_edge.c Func:hsm_client_http_edge_sign_data Line:576 send_http_workload_request failed
Error: Time:Mon Aug 13 05:47:45 2018 File:/usr/sdk/src/c/provisioning_client/src/iothub_auth_client.c Func:iothub_device_auth_generate_credentials Line:307 Failure generate hash from tpm.
Error: Time:Mon Aug 13 05:47:45 2018 File:/usr/sdk/src/c/iothub_client/src/iothub_client_authorization.c Func:IoTHubClient_Auth_Get_SasToken Line:348 failure getting credentials from device auth module
Error: Time:Mon Aug 13 05:47:45 2018 File:/usr/sdk/src/c/iothub_client/src/iothubtransport_mqtt_common.c Func:SendMqttConnectMsg Line:1944 failure getting sas token from IoTHubClient_Auth_Get_SasToken.
Error: Time:Mon Aug 13 05:47:46 2018 File:/usr/sdk/src/c/provisioning_client/adapters/hsm_client_http_edge.c Func:on_edge_hsm_http_recv Line:364 executing HTTP request fails, status=404, response_buffer={"message":"Module not found"}n, 13 )
Error: Time:Mon Aug 13 05:47:46 2018 File:/usr/sdk/src/c/provisioning_client/adapters/hsm_client_http_edge.c Func:on_edge_hsm_http_error Line:343 on_edge_hsm_http_error invoked.  reason=3
Error: Time:Mon Aug 13 05:47:46 2018 File:/usr/sdk/src/c/provisioning_client/adapters/hsm_client_http_edge.c Func:send_http_workload_request Line:483 send_request_to_edge_workload failed
Error: Time:Mon Aug 13 05:47:46 2018 File:/usr/sdk/src/c/provisioning_client/adapters/hsm_client_http_edge.c Func:hsm_client_http_edge_sign_data Line:576 send_http_workload_request failed
Error: Time:Mon Aug 13 05:47:46 2018 File:/usr/sdk/src/c/provisioning_client/src/iothub_auth_client.c Func:iothub_device_auth_generate_credentials Line:307 Failure generate hash from tpm.
Error: Time:Mon Aug 13 05:47:46 2018 File:/usr/sdk/src/c/iothub_client/src/iothub_client_authorization.c Func:IoTHubClient_Auth_Get_SasToken Line:348 failure getting credentials from device auth module
Error: Time:Mon Aug 13 05:47:46 2018 File:/usr/sdk/src/c/iothub_client/src/iothubtransport_mqtt_common.c Func:SendMqttConnectMsg Line:1944 failure getting sas token from IoTHubClient_Auth_Get_SasToken.
Error: Time:Mon Aug 13 05:47:48 2018 File:/usr/sdk/src/c/provisioning_client/adapters/hsm_client_http_edge.c Func:on_edge_hsm_http_recv Line:364 executing HTTP request fails, status=404, response_buffer={"message":"Module not found"}n, 13 )

```