### PR TITLE
Update pip to pip3 in Dockerfiles

### DIFF
--- a/{{cookiecutter.module_name}}/Dockerfile.amd64
+++ b/{{cookiecutter.module_name}}/Dockerfile.amd64
@@ -8,7 +8,7 @@ RUN apt-get update && \
 
 RUN pip3 install --upgrade pip
 COPY requirements.txt ./
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 COPY . .
 

--- a/{{cookiecutter.module_name}}/Dockerfile.amd64.debug
+++ b/{{cookiecutter.module_name}}/Dockerfile.amd64.debug
@@ -7,10 +7,10 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* 
 
 RUN pip3 install --upgrade pip
-RUN pip install setuptools
-RUN pip install ptvsd==4.1.3
+RUN pip3 install setuptools
+RUN pip3 install ptvsd==4.1.3
 COPY requirements.txt ./
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 COPY . .
 

--- a/{{cookiecutter.module_name}}/Dockerfile.arm32v7
+++ b/{{cookiecutter.module_name}}/Dockerfile.arm32v7
@@ -7,9 +7,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* 
 
 RUN pip3 install --upgrade pip 
-RUN pip install --upgrade setuptools 
+RUN pip3 install --upgrade setuptools 
 COPY requirements.txt ./
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 COPY . .
 


### PR DESCRIPTION
Dockerfiles were using pip instead of pip3 and this was causing failure for Python (now Python 3) modules to run properly - as the proper packages were not installed into the image.  Therefore, instances of `pip` were updated to `pip3` and the `Dockerfile.amd64` produces a successfully running module using the VSCode pathway to building and deploying an IoT Edge module.