### PR TITLE
Update Dockefile.arm32v7 for #26

### DIFF
--- a/{{cookiecutter.module_name}}/Dockerfile.arm32v7
+++ b/{{cookiecutter.module_name}}/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM resin/raspberrypi3-debian:stretch
+FROM balenalib/raspberrypi3-debian:stretch
 
 WORKDIR /app
 


### PR DESCRIPTION
Update Dockerfile to use newer balena repo over deprecated resin 