### PR TITLE
Specify base image arch in each dockerfile and use GA version of Python V2 SDK

### DIFF
--- a/{{cookiecutter.module_name}}/Dockerfile.amd64
+++ b/{{cookiecutter.module_name}}/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM amd64/python:3.7-slim-buster
 
 WORKDIR /app
 

--- a/{{cookiecutter.module_name}}/Dockerfile.amd64.debug
+++ b/{{cookiecutter.module_name}}/Dockerfile.amd64.debug
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM amd64/python:3.7-slim-buster
 
 WORKDIR /app
 

--- a/{{cookiecutter.module_name}}/Dockerfile.arm32v7
+++ b/{{cookiecutter.module_name}}/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM arm32v7/python:3.7-slim-buster
 
 WORKDIR /app
 

--- a/{{cookiecutter.module_name}}/Dockerfile.arm32v7.debug
+++ b/{{cookiecutter.module_name}}/Dockerfile.arm32v7.debug
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM arm32v7/python:3.7-slim-buster
 
 WORKDIR /app
 

--- a/{{cookiecutter.module_name}}/requirements.txt
+++ b/{{cookiecutter.module_name}}/requirements.txt
@@ -1,1 +1,1 @@
-azure-iot-device~=2.0.0RC11
+azure-iot-device~=2.0.0


### PR DESCRIPTION
1. Specify base image arch in each dockerfile
2. Use GA version of Python V2 SDK